### PR TITLE
Revert "Any variable name can be used in "feature_names""

### DIFF
--- a/skrules/__init__.py
+++ b/skrules/__init__.py
@@ -1,4 +1,4 @@
 from .skope_rules import SkopeRules
-from .rule import Rule, replace_feature_name
+from .rule import Rule
 
 __all__ = ['SkopeRules', 'Rule']

--- a/skrules/rule.py
+++ b/skrules/rule.py
@@ -1,13 +1,3 @@
-import re
-
-def replace_feature_name(rule, replace_dict):
-    def replace(match):
-        return replace_dict[match.group(0)]
-
-    rule = re.sub('|'.join(r'\b%s\b' % re.escape(s) for s in replace_dict),
-           replace, rule)
-    return rule
-
 class Rule:
     """ An object modelizing a logical rule and add factorization methods.
     It is used to simplify rules and deduplicate them.
@@ -66,4 +56,3 @@ class Rule:
                 [feature, symbol, str(self.agg_dict[(feature, symbol)])])
                 for feature, symbol in sorted(self.agg_dict.keys())
                 ])
-

--- a/skrules/tests/test_rule.py
+++ b/skrules/tests/test_rule.py
@@ -1,6 +1,6 @@
 from sklearn.utils.testing import assert_equal, assert_not_equal
 
-from skrules import Rule, replace_feature_name
+from skrules import Rule
 
 
 def test_rule():
@@ -53,13 +53,3 @@ def test_equals_rule():
 
     rule3 = "a < 3.0 and a == a"
     assert_equal(rule3, str(Rule(rule3)))
-
-
-def test_replace_feature_name():
-    rule = "__C__0 <= 3 and __C__1 > 4"
-    real_rule = "$b <= 3 and c(4) > 4"
-    replace_dict = {
-                    "__C__0": "$b",
-                    "__C__1": "c(4)"
-                    }
-    assert_equal(replace_feature_name(rule, replace_dict=replace_dict), real_rule)


### PR DESCRIPTION
Reverts scikit-learn-contrib/skope-rules#4
A bug persists with predict_top_rules. I will fix it and add a test case.