### PR TITLE
fix bug in score top rules

### DIFF
--- a/skrules/skope_rules.py
+++ b/skrules/skope_rules.py
@@ -532,7 +532,7 @@ class SkopeRules(BaseEstimator):
                              % (X.shape[1], self.n_features_))
 
         df = pandas.DataFrame(X, columns=self.feature_names_)
-        selected_rules = self.rules_
+        selected_rules = self.rules_without_feature_names_
 
         scores = np.zeros(X.shape[0])
         for (k, r) in enumerate(list((selected_rules))):


### PR DESCRIPTION
The score top rules uses wrong argument when selecting rules. The method was broke making it unusable.