### PR TITLE
Remove unnecessary checks for numpy/scipy in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,5 @@
-import sys
 from setuptools import setup, find_packages
 
-
-try:
-    import numpy
-except ImportError:
-    print('numpy is required during installation')
-    sys.exit(1)
-
-try:
-    import scipy
-except ImportError:
-    print('scipy is required during installation')
-    sys.exit(1)
 
 setup(name='skope-rules',
       version='1.0.0',

--- a/skrules/tests/test_common.py
+++ b/skrules/tests/test_common.py
@@ -4,8 +4,8 @@ from skrules.datasets import load_credit_data
 
 
 def test_classifier():
-    return check_estimator(SkopeRules)
+    check_estimator(SkopeRules)
 
 
 def test_load_credit_data():
-    return load_credit_data().data.shape[0] == 30000
+    assert load_credit_data().data.shape[0] == 30000


### PR DESCRIPTION
These deps are listing in install_requires, so will get installed by pip.

Addresses issue #19.

Interesting project, thanks for your dev efforts folks :-)