### PR TITLE
New features

### DIFF
--- a/examples/plot_credit_default.py
+++ b/examples/plot_credit_default.py
@@ -151,7 +151,7 @@ plt.show()
 clf = SkopeRules(
     max_depth_duplication=3, max_depth=3, max_features=0.5,
     max_samples_features=0.5, random_state=rng, n_estimators=20,
-    feature_names=feature_names, recall_min=0.04, precision_min=0.6)
+    feature_names=feature_names, filtering_criteria={'recall': 0.04, 'precision': 0.6})
 clf.fit(X_train, y_train)
 
 # in the score_top_rules method, a score of k means that rule number k

--- a/examples/plot_credit_default.py
+++ b/examples/plot_credit_default.py
@@ -151,7 +151,7 @@ plt.show()
 clf = SkopeRules(
     max_depth_duplication=3, max_depth=3, max_features=0.5,
     max_samples_features=0.5, random_state=rng, n_estimators=20,
-    feature_names=feature_names, filtering_criteria={'recall': 0.04, 'precision': 0.6})
+    feature_names=feature_names, recall_min=0.04, precision_min=0.6)
 clf.fit(X_train, y_train)
 
 # in the score_top_rules method, a score of k means that rule number k

--- a/notebooks/demo_clustering.ipynb
+++ b/notebooks/demo_clustering.ipynb
@@ -110,40 +110,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Cluster 0:\n",
-      "[('Agility <= 81.5 and Free_kick_accuracy > 56.0 and Heading_accuracy > 58.5', (0.93548387096774188, 0.8529411764705882, 10))]\n",
-      "Cluster 1:\n",
-      "[('Aggression <= 76.5 and Agility > 81.5 and Balance > 66.5', (1.0, 0.77419354838709675, 8))]\n",
-      "Cluster 2:\n",
-      "[('Curve <= 61.5 and Heading_accuracy > 82.5', (1.0, 0.7857142857142857, 8))]\n",
-      "Cluster 3:\n",
-      "[('Curve <= 28.0', (1.0, 1.0, 4))]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "warnings.filterwarnings('ignore') #To deals with warning raised by max_samples=1 (see below).\n",
-    "#With max_samples=1, there is no Out-Of-Bag sample to evaluate performance (it is evaluated on all samples. \n",
-    "#As there are less than 100 samples and this is a clustering-oriented task, the risk of overfitting is not \n",
-    "#dramatic here.\n",
+    "warnings.filterwarnings('ignore') # To deals with warning raised by max_samples=1 (see below).\n",
+    "# With max_samples=1, there is no Out-Of-Bag sample to evaluate performance (it is evaluated on all samples. \n",
+    "# As there are less than 100 samples and this is a clustering-oriented task, the risk of overfitting is not \n",
+    "# dramatic here.\n",
     "\n",
     "i_cluster = 0\n",
     "for i_cluster in range(4):\n",
     "    X_train = data.drop(['Name', 'Preferred_Positions', 'cluster'], axis=1)\n",
-    "    y_train = (data['cluster']==i_cluster)*1\n",
-    "    skope_rules_clf = SkopeRules(feature_names=feature_names, random_state=42, n_estimators=5,\n",
-    "                                   recall_min=0.5, precision_min=0.5, max_depth_duplication=0,\n",
-    "                                   max_samples=1., max_depth=3)\n",
+    "    y_train = (data['cluster'] == i_cluster) * 1\n",
+    "    skope_rules_clf = SkopeRules(feature_names=feature_names, \n",
+    "                                 random_state=42,\n",
+    "                                 n_estimators=5,\n",
+    "                                 filtering_criteria={'precision': 0.5, 'recall': 0.5},\n",
+    "                                 duplication_criterion=\"f1\",\n",
+    "                                 max_depth_duplication=0,\n",
+    "                                 max_samples=1.,\n",
+    "                                 max_depth=3)\n",
     "    skope_rules_clf.fit(X_train, y_train)\n",
-    "    print('Cluster '+str(i_cluster)+':')\n",
-    "    #print(data.query('cluster=='+str(i_cluster))[['Name', 'Preferred_Positions']])\n",
+    "    print('Cluster ' + str(i_cluster) + ':')\n",
     "    print(skope_rules_clf.rules_)"
    ]
   },
@@ -186,8 +175,8 @@
    ],
    "source": [
     "for i_cluster in range(4):\n",
-    "    print('5 players from cluster '+str(i_cluster)+':')\n",
-    "    print(data.query(\"cluster==\"+str(i_cluster))['Name'].sample(5, random_state=42).tolist()) # Get 5 random players per cluster\n",
+    "    print('5 players from cluster {}:'.format(i_cluster))\n",
+    "    print(data.query(\"cluster == {}\".format(i_cluster))['Name'].sample(5, random_state=42).tolist()) # Get 5 random players per cluster\n",
     "    print()"
    ]
   },
@@ -224,7 +213,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.5.6"
   }
  },
  "nbformat": 4,

--- a/notebooks/demo_titanic.ipynb
+++ b/notebooks/demo_titanic.ipynb
@@ -132,10 +132,14 @@
     "decision_tree_clf.fit(X_train, y_train)\n",
     "\n",
     "# Train a skope-rules-boosting classifier\n",
-    "skope_rules_clf = SkopeRules(feature_names=feature_names, random_state=42, n_estimators=30,\n",
-    "                               recall_min=0.05, precision_min=0.9,\n",
-    "                               max_samples=0.7,\n",
-    "                               max_depth_duplication= 4, max_depth = 5)\n",
+    "skope_rules_clf = SkopeRules(feature_names=feature_names,\n",
+    "                             random_state=42, \n",
+    "                             n_estimators=30,\n",
+    "                             filtering_criteria={'precision': 0.9, 'recall': 0.05},\n",
+    "                             max_samples=0.7,\n",
+    "                             max_depth_duplication=4,\n",
+    "                             duplication_criterion=\"f1\",\n",
+    "                             max_depth=5)\n",
     "skope_rules_clf.fit(X_train, y_train)\n",
     "\n",
     "\n",
@@ -665,7 +669,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.5.6"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-numpy>=1.10.4
-scikit-learn>=0.17.1
+numpy>=1.11.0
+scikit-learn>=0.22
 scipy>=0.17.0
 pandas>=0.18.1
 numpydoc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.10.4
-scikit-learn>=0.17.1,<=0.23.2
+scikit-learn>=0.17.1
 scipy>=0.17.0
 pandas>=0.18.1
 numpydoc

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.10.4
-scikit-learn>=0.17.1
+scikit-learn>=0.17.1,<=0.23.2
 scipy>=0.17.0
 pandas>=0.18.1
 numpydoc

--- a/skrules/__init__.py
+++ b/skrules/__init__.py
@@ -1,4 +1,4 @@
 from .skope_rules import SkopeRules
 from .rule import Rule, replace_feature_name
 
-__all__ = ['SkopeRules', 'Rule']
+__all__ = ['SkopeRules', 'Rule', 'replace_feature_name']

--- a/skrules/datasets/credit_data.py
+++ b/skrules/datasets/credit_data.py
@@ -16,28 +16,59 @@ Science.
 
 """
 
+
+from os.path import exists, join
+from urllib.request import urlretrieve
+from collections import namedtuple
+import hashlib
+
 import pandas as pd
 import numpy as np
-from sklearn.datasets.base import get_data_home, Bunch
-from sklearn.datasets.base import _fetch_remote, RemoteFileMetadata
-from os.path import exists, join
 
+from sklearn.datasets import get_data_home
+from sklearn.utils import Bunch
+
+
+# Because of sklearn.datasets.base and  module is  deprecated in version 0.22
+# and will be removed in version 0.24
+# We delete "from sklearn.datasets.base import _fetch_remote, RemoteFileMetadata"
+# The function _sha256 of sklearn.datasets.base is redefined
+
+def calculate_sha256(file_path):
+    """Calculate the sha256 hash of the file at path."""
+    sha256hash = hashlib.sha256()
+    chunk_size = 8192
+    with open(file_path, "rb") as file:
+        while True:
+            buffer = file.read(chunk_size)
+            if not buffer:
+                break
+            sha256hash.update(buffer)
+    return sha256hash.hexdigest()
 
 def load_credit_data():
     sk_data_dir = get_data_home()
+    RemoteFileMetadata = namedtuple('RemoteFileMetadata',
+                                ['filename', 'url', 'checksum'])
     archive = RemoteFileMetadata(
         filename='default of credit card clients.xls',
         url='https://archive.ics.uci.edu/ml/machine-learning-databases/'
             '00350/default%20of%20credit%20card%20clients.xls',
         checksum=('30c6be3abd8dcfd3e6096c828bad8c2f'
                   '011238620f5369220bd60cfc82700933'))
-
-    if not exists(join(sk_data_dir, archive.filename)):
-        _fetch_remote(archive, dirname=sk_data_dir)
-
-    data = pd.read_excel(join(sk_data_dir, archive.filename),
-                         sheet_name='Data', header=1)
-
+    file_path = join(sk_data_dir, archive.filename)
+    if not exists(file_path):
+        urlretrieve(archive.url, file_path)
+        checksum = calculate_sha256(file_path)
+        if archive.checksum != checksum:
+            raise IOError("{} has an SHA256 checksum ({}) "
+                          "differing from expected ({}), "
+                          "file may be corrupted.".format(file_path,
+                                                          checksum,
+                                                          archive.checksum))
+    data = pd.read_excel(file_path,
+                         sheet_name='Data',
+                         header=1)
     dataset = Bunch(
         data=(data.drop('default payment next month', axis=1)),
         target=np.array(data['default payment next month'])

--- a/skrules/skope_rules.py
+++ b/skrules/skope_rules.py
@@ -14,6 +14,12 @@ from sklearn.tree import _tree
 
 from .rule import Rule, replace_feature_name
 
+from .utils import (check_filtering_criteria, check_deduplication_criterion,
+                    check_custom_func, check_consistency,
+                    check_max_depth_duplication, check_max_samples)
+from .utils import (get_confusion_matrix, f1_score, mcc_score,
+                    precision, recall)
+
 INTEGER_TYPES = (numbers.Integral, np.integer)
 BASE_FEATURE_NAME = "__C__"
 
@@ -28,11 +34,21 @@ class SkopeRules(BaseEstimator):
         The names of each feature to be used for returning rules in string
         format.
 
-    precision_min : float, optional (default=0.5)
-        The minimal precision of a rule to be selected.
+    filtering_criteria: dict, optional
+                        default={'precision': 0.5, 'recall': 0.01}
+        The criteria to be used for filtering the rules.
+        In the form {criterion: min_value}.
+        The keys can be among ('precision', 'recall', 'f1', 'mcc', 'custom_func').
 
-    recall_min : float, optional (default=0.01)
-        The minimal recall of a rule to be selected.
+    duplication_criterion: str, optional (default='f1')
+        The criterion to be used for deduplicating the rules.
+        Either 'f1', 'mcc' or 'custom_func'.
+
+    custom_func: FunctionType, optional (default=None)
+        A personalised function that can be used as either/both a filtering
+        or/and deduplication criterion.
+        Has to take tuple of size 4 which is supposed to be the confusion matrix
+        elements (tn, fp, fn, tp) (in that order).
 
     n_estimators : int, optional (default=10)
         The number of base estimators (rules) to use for prediction. More are
@@ -139,8 +155,9 @@ class SkopeRules(BaseEstimator):
 
     def __init__(self,
                  feature_names=None,
-                 precision_min=0.5,
-                 recall_min=0.01,
+                 filtering_criteria={'precision': 0.5, 'recall': 0.01},
+                 duplication_criterion='f1',
+                 custom_func=None,
                  n_estimators=10,
                  max_samples=.8,
                  max_samples_features=1.,
@@ -153,8 +170,16 @@ class SkopeRules(BaseEstimator):
                  n_jobs=1,
                  random_state=None,
                  verbose=0):
-        self.precision_min = precision_min
-        self.recall_min = recall_min
+        check_filtering_criteria(filtering_criteria)
+        self.filtering_criteria = filtering_criteria
+        check_deduplication_criterion(duplication_criterion)
+        self.duplication_criterion = duplication_criterion
+        check_custom_func(custom_func)
+        self.custom_func = custom_func
+        check_consistency(self.custom_func,
+                          self.duplication_criterion,
+                          self.filtering_criteria
+                          )
         self.feature_names = feature_names
         self.n_estimators = n_estimators
         self.max_samples = max_samples
@@ -162,6 +187,7 @@ class SkopeRules(BaseEstimator):
         self.bootstrap = bootstrap
         self.bootstrap_features = bootstrap_features
         self.max_depth = max_depth
+        check_max_depth_duplication(max_depth_duplication)
         self.max_depth_duplication = max_depth_duplication
         self.max_features = max_features
         self.min_samples_split = min_samples_split
@@ -206,10 +232,6 @@ class SkopeRules(BaseEstimator):
                              " in the data, but the data contains only one"
                              " class: %r" % self.classes_[0])
 
-        if not isinstance(self.max_depth_duplication, int) \
-                and self.max_depth_duplication is not None:
-            raise ValueError("max_depth_duplication should be an integer"
-                             )
         if not set(self.classes_) == set([0, 1]):
             warn("Found labels %s. This method assumes target class to be"
                  " labeled as 1 and normal data to be labeled as 0. Any label"
@@ -220,28 +242,7 @@ class SkopeRules(BaseEstimator):
 
         # ensure that max_samples is in [1, n_samples]:
         n_samples = X.shape[0]
-
-        if isinstance(self.max_samples, str):
-            raise ValueError('max_samples (%s) is not supported.'
-                             'Valid choices are: "auto", int or'
-                             'float' % self.max_samples)
-
-        elif isinstance(self.max_samples, INTEGER_TYPES):
-            if self.max_samples > n_samples:
-                warn("max_samples (%s) is greater than the "
-                     "total number of samples (%s). max_samples "
-                     "will be set to n_samples for estimation."
-                     % (self.max_samples, n_samples))
-                max_samples = n_samples
-            else:
-                max_samples = self.max_samples
-        else:  # float
-            if not (0. < self.max_samples <= 1.):
-                raise ValueError("max_samples must be in (0, 1], got %r"
-                                 % self.max_samples)
-            max_samples = int(self.max_samples * X.shape[0])
-
-        self.max_samples_ = max_samples
+        self.max_samples_ = check_max_samples(self.max_samples, n_samples)
 
         self.rules_ = {}
         self.estimators_ = []
@@ -334,8 +335,8 @@ class SkopeRules(BaseEstimator):
                                                 self.estimators_features_):
 
             # Create mask for OOB samples
-            mask = ~indices_to_mask(samples, n_samples)            
-                        
+            mask = ~indices_to_mask(samples, n_samples)
+
             if sum(mask) == 0:
                 warn("OOB evaluation not possible: doing it in-bag."
                      " Performance evaluation is likely to be wrong"
@@ -355,7 +356,8 @@ class SkopeRules(BaseEstimator):
                 y_oob = np.array((y_oob != 0))
 
                 # Add OOB performances to rules:
-                rules_from_tree = [(r, self._eval_rule_perf(r, X_oob, y_oob))
+                # rule <-> (rule_string, confusion matrix)
+                rules_from_tree = [(r, get_confusion_matrix(r, X_oob, y_oob))
                                    for r in set(rules_from_tree)]
                 rules_ += rules_from_tree
 
@@ -363,36 +365,68 @@ class SkopeRules(BaseEstimator):
         rules_ = [
             tuple(rule)
             for rule in
-            [Rule(r, args=args) for r, args in rules_]]
+            [Rule(r, args=confusion_matrix)
+             for r, confusion_matrix in rules_]
+            ]
 
-        # keep only rules verifying precision_min and recall_min:
-        for rule, score in rules_:
-            if score[0] >= self.precision_min and score[1] >= self.recall_min:
-                if rule in self.rules_:
-                    # update the score to the new mean
-                    c = self.rules_[rule][2] + 1
-                    b = self.rules_[rule][1] + 1. / c * (
-                        score[1] - self.rules_[rule][1])
-                    a = self.rules_[rule][0] + 1. / c * (
-                        score[0] - self.rules_[rule][0])
+        # Filter the rules according to filtering_criteria
+        for rule in rules_:
+            rule_str, confusion_matrix = rule
+            # retrieve all scores info about the rule
+            info_rule = {'precision': precision(confusion_matrix),
+                         'recall': recall(confusion_matrix),
+                         'f1': f1_score(confusion_matrix),
+                         'mcc': mcc_score(confusion_matrix)
+                         }
+            if self.custom_func is not None:
+                info_rule['custom_func'] = self.custom_func(confusion_matrix)
 
-                    self.rules_[rule] = (a, b, c)
+            if all(x < y for x, y in
+                    zip(self.filtering_criteria.values(),
+                        [info_rule[criterion]
+                         for criterion in self.filtering_criteria
+                         ]
+                        )
+                   ):
+                if rule_str in self.rules_:
+                    # update the confusion matrix to the new mean
+                    def update(x, y, z):
+                        return round(x + 1. / y * (z - x))
+                    nb = self.rules_[rule_str][1] + 1
+                    new_confusion_matrix = [update(self.rules_[rule_str][0][i],
+                                                   nb,
+                                                   confusion_matrix[i]
+                                                   )
+                                            for i in range(4)]
+                    self.rules_[rule_str] = (tuple(new_confusion_matrix), nb)
                 else:
-                    self.rules_[rule] = (score[0], score[1], 1)
+                    self.rules_[rule_str] = (confusion_matrix, 1)
 
-        self.rules_ = sorted(self.rules_.items(),
-                             key=lambda x: (x[1][0], x[1][1]), reverse=True)
+        # Replace (confusion_matrix, nb) tuple by confusion_matrix
+        for key in self.rules_:
+            self.rules_[key] = self.rules_[key][0]
+
+        # Transform dic object into list
+        self.rules_ = list(self.rules_.items())
 
         # Deduplicate the rule using semantic tree
         if self.max_depth_duplication is not None:
-            self.rules_ = self.deduplicate(self.rules_)
+            self.rules_ = self._deduplicate(self.rules_)
 
-        self.rules_ = sorted(self.rules_, key=lambda x: - self.f1_score(x))
+        # Sort the rules according to duplication_criterion criterion
+        func = self.custom_func
+        if self.custom_func is None:
+            func = globals()[self.duplication_criterion + '_score']
+
+        self.rules_ = sorted(self.rules_, key=lambda x: func(x[1]), reverse=True)
+
         self.rules_without_feature_names_ = self.rules_
 
         # Replace generic feature names by real feature names
-        self.rules_ = [(replace_feature_name(rule, self.feature_dict_), perf)
-                       for rule, perf in self.rules_]
+        self.rules_ = [(replace_feature_name(rule, self.feature_dict_),
+                        args)
+                       for rule, args in self.rules_
+                       ]
 
         return self
 
@@ -452,7 +486,7 @@ class SkopeRules(BaseEstimator):
 
         scores = np.zeros(X.shape[0])
         for (r, w) in selected_rules:
-            scores[list(df.query(r).index)] += w[0]
+            scores[list(df.query(r).index)] += precision(w)
 
         return scores
 
@@ -612,20 +646,24 @@ class SkopeRules(BaseEstimator):
 
         return rules if len(rules) > 0 else 'True'
 
-    def _eval_rule_perf(self, rule, X, y):
-        detected_index = list(X.query(rule).index)
-        if len(detected_index) <= 1:
-            return (0, 0)
-        y_detected = y[detected_index]
-        true_pos = y_detected[y_detected > 0].sum()
-        if true_pos == 0:
-            return (0, 0)
-        pos = y[y > 0].sum()
-        return y_detected.mean(), float(true_pos) / pos
+    def _deduplicate(self, rules):
+        """Select the best rules according to the duplication_criterion
+        from the clusters of rules built by find_similar_rulesets
 
-    def deduplicate(self, rules):
-        return [max(rules_set, key=self.f1_score)
-                for rules_set in self._find_similar_rulesets(rules)]
+        Arguments:
+            rules: list of rules
+
+        Returns:
+            list of rules
+        """
+        if self.custom_func is None:
+            func = globals()[self.duplication_criterion + '_score']
+        else:
+            func = self.custom_func
+
+        return [max(rules_set, key=lambda x: func(x[1]))
+                for rules_set in self._find_similar_rulesets(rules)
+                ]
 
     def _find_similar_rulesets(self, rules):
         """Create clusters of rules using a decision tree based
@@ -688,7 +726,3 @@ class SkopeRules(BaseEstimator):
         res = split_with_best_feature(rules, self.max_depth_duplication)
         breadth_first_search(res, leaves=leaves)
         return leaves
-
-    def f1_score(self, x):
-        return 2 * x[1][0] * x[1][1] / \
-               (x[1][0] + x[1][1]) if (x[1][0] + x[1][1]) > 0 else 0

--- a/skrules/tests/test_common.py
+++ b/skrules/tests/test_common.py
@@ -4,7 +4,7 @@ from skrules.datasets import load_credit_data
 
 
 def test_classifier():
-    check_estimator(SkopeRules)
+    check_estimator(SkopeRules())
 
 
 def test_load_credit_data():

--- a/skrules/tests/test_common.py
+++ b/skrules/tests/test_common.py
@@ -4,7 +4,7 @@ from skrules.datasets import load_credit_data
 
 
 def test_classifier():
-    check_estimator(SkopeRules())
+    check_estimator(SkopeRules)
 
 
 def test_load_credit_data():

--- a/skrules/tests/test_rule.py
+++ b/skrules/tests/test_rule.py
@@ -1,58 +1,58 @@
-from sklearn.utils.testing import assert_equal, assert_not_equal
-
+import pandas as pd
+import numpy as np
 from skrules import Rule, replace_feature_name
-
+from skrules.utils import precision, recall, f1_score, mcc_score, get_confusion_matrix
 
 def test_rule():
-    assert_equal(Rule('a <= 10 and a <= 12'),
-                 Rule('a <= 10'))
-    assert_equal(Rule('a <= 10 and a <= 12 and a > 3'),
-                 Rule('a > 3 and a <= 10'))
+    assert(Rule('a <= 10 and a <= 12')
+           == Rule('a <= 10'))
 
-    assert_equal(Rule('a <= 10 and a <= 10 and a > 3'),
-                 Rule('a > 3 and a <= 10'))
+    assert(Rule('a <= 10 and a <= 12 and a > 3')
+           == Rule('a > 3 and a <= 10'))
 
-    assert_equal(Rule('a <= 10 and a <= 12 and b > 3 and b > 6'),
-                 Rule('a <= 10 and b > 6'))
+    assert(Rule('a <= 10 and a <= 10 and a > 3')
+           == Rule('a > 3 and a <= 10'))
 
-    assert_equal(len({Rule('a <= 2 and a <= 3'),
-                      Rule('a <= 2')
-                      }), 1)
+    assert(Rule('a <= 10 and a <= 12 and b > 3 and b > 6')
+           == Rule('a <= 10 and b > 6'))
 
-    assert_equal(len({Rule('a > 2 and a > 3 and b <= 2 and b <= 3'),
-                      Rule('a > 3 and b <= 2')
-                      }), 1)
+    assert(len({Rule('a <= 2 and a <= 3'), Rule('a <= 2')})
+           == 1)
 
-    assert_equal(len({Rule('a <= 3 and b <= 2'),
-                      Rule('b <= 2 and a <= 3')
-                      }), 1)
+    assert(len({Rule('a > 2 and a > 3 and b <= 2 and b <= 3'),
+                Rule('a > 3 and b <= 2')
+                })
+           == 1)
+
+    assert(len({Rule('a <= 3 and b <= 2'), Rule('b <= 2 and a <= 3')})
+           == 1)
 
 
 def test_hash_rule():
-    assert_equal(len({
-                        Rule('a <= 2 and a <= 3'),
-                        Rule('a <= 2')
-                      }), 1)
-    assert_not_equal(len({
-                        Rule('a <= 4 and a <= 3'),
-                        Rule('a <= 2')
-                      }), 1)
+    assert(len({Rule('a <= 2 and a <= 3'),
+                Rule('a <= 2')
+                })
+           == 1)
+    assert(len({Rule('a <= 4 and a <= 3'),
+                Rule('a <= 2')
+                })
+           != 1)
 
 
 def test_str_rule():
     rule = 'a <= 10.0 and b > 3.0'
-    assert_equal(rule, str(Rule(rule)))
+    assert(rule == str(Rule(rule)))
 
 
 def test_equals_rule():
     rule = "a == a"
-    assert_equal(rule, str(Rule(rule)))
+    assert(rule == str(Rule(rule)))
 
     rule2 = "a == a and a == a"
-    assert_equal(rule, str(Rule(rule2)))
+    assert(rule == str(Rule(rule2)))
 
     rule3 = "a < 3.0 and a == a"
-    assert_equal(rule3, str(Rule(rule3)))
+    assert(rule3 == str(Rule(rule3)))
 
 
 def test_replace_feature_name():
@@ -62,4 +62,58 @@ def test_replace_feature_name():
                     "__C__0": "$b",
                     "__C__1": "c(4)"
                     }
-    assert_equal(replace_feature_name(rule, replace_dict=replace_dict), real_rule)
+    assert(replace_feature_name(rule, replace_dict=replace_dict)
+           == real_rule)
+
+
+def test_precision():
+    rule0 = ('a > 0', (0, 0, 0, 0))
+    rule1 = ('a > 0', (0, 1, 0, 1))
+
+    assert precision(rule0[1]) == 0
+    assert precision(rule1[1]) == 0.5
+
+
+def test_recall():
+    rule0 = ('a > 0', (0, 0, 0, 0))
+    rule1 = ('a > 0', (0, 0, 1, 1))
+
+    assert recall(rule0[1]) == 0
+    assert recall(rule1[1]) == 0.5
+
+
+def test_f1_score():
+    rule0 = ('a > 0', (0, 0, 0, 0))
+    rule1 = ('a > 0', (0, 1, 1, 1))
+
+    assert f1_score(rule0[1]) == 0
+    assert f1_score(rule1[1]) == 0.5
+
+
+def test_mcc_score():
+    rule0 = ('a > 0', (0, 1, 0, 1))
+    rule1 = ('a > 0', (0, 0, 1, 1))
+    rule2 = ('a > 0', (1, 1, 0, 0))
+    rule3 = ('a > 0', (1, 0, 1, 0))
+    rule4 = ('a > 0', (0, 0, 0, 0))
+    rule5 = ('a > 0', (1, 0, 0, 1))
+
+    assert mcc_score(rule0[1]) == 0
+    assert mcc_score(rule1[1]) == 0
+    assert mcc_score(rule2[1]) == 0
+    assert mcc_score(rule3[1]) == 0
+    assert mcc_score(rule4[1]) == 0
+    assert mcc_score(rule5[1]) == 1
+
+
+def test_get_confusion_matrix():
+    X = pd.DataFrame([[0, 1, 1], [1, 0, 1]], columns=['a', 'b', 'c'])
+    y = np.array([1, 0])
+
+    rule0 = 'a > 0'
+    rule1 = 'b > 0'
+    rule2 = 'c > 0'
+
+    assert get_confusion_matrix(rule0, X, y) == (0, 1, 1, 0)
+    assert get_confusion_matrix(rule1, X, y) == (1, 0, 0, 1)
+    assert get_confusion_matrix(rule2, X, y) == (0, 1, 0, 1)

--- a/skrules/tests/test_rule.py
+++ b/skrules/tests/test_rule.py
@@ -1,58 +1,60 @@
-from sklearn.utils.testing import assert_equal, assert_not_equal
-
+import pandas as pd
+import numpy as np
 from skrules import Rule, replace_feature_name
+
+from skrules.utils import precision, recall, f1_score, mcc_score, get_confusion_matrix
 
 
 def test_rule():
-    assert_equal(Rule('a <= 10 and a <= 12'),
-                 Rule('a <= 10'))
-    assert_equal(Rule('a <= 10 and a <= 12 and a > 3'),
-                 Rule('a > 3 and a <= 10'))
+    assert(Rule('a <= 10 and a <= 12')
+           == Rule('a <= 10'))
 
-    assert_equal(Rule('a <= 10 and a <= 10 and a > 3'),
-                 Rule('a > 3 and a <= 10'))
+    assert(Rule('a <= 10 and a <= 12 and a > 3')
+           == Rule('a > 3 and a <= 10'))
 
-    assert_equal(Rule('a <= 10 and a <= 12 and b > 3 and b > 6'),
-                 Rule('a <= 10 and b > 6'))
+    assert(Rule('a <= 10 and a <= 10 and a > 3')
+           == Rule('a > 3 and a <= 10'))
 
-    assert_equal(len({Rule('a <= 2 and a <= 3'),
-                      Rule('a <= 2')
-                      }), 1)
+    assert(Rule('a <= 10 and a <= 12 and b > 3 and b > 6')
+           == Rule('a <= 10 and b > 6'))
 
-    assert_equal(len({Rule('a > 2 and a > 3 and b <= 2 and b <= 3'),
-                      Rule('a > 3 and b <= 2')
-                      }), 1)
+    assert(len({Rule('a <= 2 and a <= 3'), Rule('a <= 2')})
+           == 1)
 
-    assert_equal(len({Rule('a <= 3 and b <= 2'),
-                      Rule('b <= 2 and a <= 3')
-                      }), 1)
+    assert(len({Rule('a > 2 and a > 3 and b <= 2 and b <= 3'),
+                Rule('a > 3 and b <= 2')
+                })
+           == 1)
+
+    assert(len({Rule('a <= 3 and b <= 2'), Rule('b <= 2 and a <= 3')})
+           == 1)
 
 
 def test_hash_rule():
-    assert_equal(len({
-                        Rule('a <= 2 and a <= 3'),
-                        Rule('a <= 2')
-                      }), 1)
-    assert_not_equal(len({
-                        Rule('a <= 4 and a <= 3'),
-                        Rule('a <= 2')
-                      }), 1)
+    assert(len({Rule('a <= 2 and a <= 3'),
+                Rule('a <= 2')
+                })
+           == 1)
+    assert(len({Rule('a <= 4 and a <= 3'),
+                Rule('a <= 2')
+                })
+           != 1)
 
 
 def test_str_rule():
     rule = 'a <= 10.0 and b > 3.0'
-    assert_equal(rule, str(Rule(rule)))
+    assert(rule == str(Rule(rule)))
 
 
 def test_equals_rule():
     rule = "a == a"
-    assert_equal(rule, str(Rule(rule)))
+    assert(rule == str(Rule(rule)))
 
     rule2 = "a == a and a == a"
-    assert_equal(rule, str(Rule(rule2)))
+    assert(rule == str(Rule(rule2)))
 
     rule3 = "a < 3.0 and a == a"
-    assert_equal(rule3, str(Rule(rule3)))
+    assert(rule3 == str(Rule(rule3)))
 
 
 def test_replace_feature_name():
@@ -62,4 +64,58 @@ def test_replace_feature_name():
                     "__C__0": "$b",
                     "__C__1": "c(4)"
                     }
-    assert_equal(replace_feature_name(rule, replace_dict=replace_dict), real_rule)
+    assert(replace_feature_name(rule, replace_dict=replace_dict)
+           == real_rule)
+
+
+def test_precision():
+    rule0 = ('a > 0', (0, 0, 0, 0))
+    rule1 = ('a > 0', (0, 1, 0, 1))
+
+    assert precision(rule0[1]) == 0
+    assert precision(rule1[1]) == 0.5
+
+
+def test_recall():
+    rule0 = ('a > 0', (0, 0, 0, 0))
+    rule1 = ('a > 0', (0, 0, 1, 1))
+
+    assert recall(rule0[1]) == 0
+    assert recall(rule1[1]) == 0.5
+
+
+def test_f1_score():
+    rule0 = ('a > 0', (0, 0, 0, 0))
+    rule1 = ('a > 0', (0, 1, 1, 1))
+
+    assert f1_score(rule0[1]) == 0
+    assert f1_score(rule1[1]) == 0.5
+
+
+def test_mcc_score():
+    rule0 = ('a > 0', (0, 1, 0, 1))
+    rule1 = ('a > 0', (0, 0, 1, 1))
+    rule2 = ('a > 0', (1, 1, 0, 0))
+    rule3 = ('a > 0', (1, 0, 1, 0))
+    rule4 = ('a > 0', (0, 0, 0, 0))
+    rule5 = ('a > 0', (1, 0, 0, 1))
+
+    assert mcc_score(rule0[1]) == 0
+    assert mcc_score(rule1[1]) == 0
+    assert mcc_score(rule2[1]) == 0
+    assert mcc_score(rule3[1]) == 0
+    assert mcc_score(rule4[1]) == 0
+    assert mcc_score(rule5[1]) == 1
+
+
+def test_get_confusion_matrix():
+    X = pd.DataFrame([[0, 1, 1], [1, 0, 1]], columns=['a', 'b', 'c'])
+    y = np.array([1, 0])
+
+    rule0 = 'a > 0'
+    rule1 = 'b > 0'
+    rule2 = 'c > 0'
+
+    assert get_confusion_matrix(rule0, X, y) == (0, 1, 1, 0)
+    assert get_confusion_matrix(rule1, X, y) == (1, 0, 0, 1)
+    assert get_confusion_matrix(rule2, X, y) == (0, 1, 0, 1)

--- a/skrules/tests/test_rule.py
+++ b/skrules/tests/test_rule.py
@@ -1,58 +1,58 @@
-import pandas as pd
-import numpy as np
+from sklearn.utils.testing import assert_equal, assert_not_equal
+
 from skrules import Rule, replace_feature_name
-from skrules.utils import precision, recall, f1_score, mcc_score, get_confusion_matrix
+
 
 def test_rule():
-    assert(Rule('a <= 10 and a <= 12')
-           == Rule('a <= 10'))
+    assert_equal(Rule('a <= 10 and a <= 12'),
+                 Rule('a <= 10'))
+    assert_equal(Rule('a <= 10 and a <= 12 and a > 3'),
+                 Rule('a > 3 and a <= 10'))
 
-    assert(Rule('a <= 10 and a <= 12 and a > 3')
-           == Rule('a > 3 and a <= 10'))
+    assert_equal(Rule('a <= 10 and a <= 10 and a > 3'),
+                 Rule('a > 3 and a <= 10'))
 
-    assert(Rule('a <= 10 and a <= 10 and a > 3')
-           == Rule('a > 3 and a <= 10'))
+    assert_equal(Rule('a <= 10 and a <= 12 and b > 3 and b > 6'),
+                 Rule('a <= 10 and b > 6'))
 
-    assert(Rule('a <= 10 and a <= 12 and b > 3 and b > 6')
-           == Rule('a <= 10 and b > 6'))
+    assert_equal(len({Rule('a <= 2 and a <= 3'),
+                      Rule('a <= 2')
+                      }), 1)
 
-    assert(len({Rule('a <= 2 and a <= 3'), Rule('a <= 2')})
-           == 1)
+    assert_equal(len({Rule('a > 2 and a > 3 and b <= 2 and b <= 3'),
+                      Rule('a > 3 and b <= 2')
+                      }), 1)
 
-    assert(len({Rule('a > 2 and a > 3 and b <= 2 and b <= 3'),
-                Rule('a > 3 and b <= 2')
-                })
-           == 1)
-
-    assert(len({Rule('a <= 3 and b <= 2'), Rule('b <= 2 and a <= 3')})
-           == 1)
+    assert_equal(len({Rule('a <= 3 and b <= 2'),
+                      Rule('b <= 2 and a <= 3')
+                      }), 1)
 
 
 def test_hash_rule():
-    assert(len({Rule('a <= 2 and a <= 3'),
-                Rule('a <= 2')
-                })
-           == 1)
-    assert(len({Rule('a <= 4 and a <= 3'),
-                Rule('a <= 2')
-                })
-           != 1)
+    assert_equal(len({
+                        Rule('a <= 2 and a <= 3'),
+                        Rule('a <= 2')
+                      }), 1)
+    assert_not_equal(len({
+                        Rule('a <= 4 and a <= 3'),
+                        Rule('a <= 2')
+                      }), 1)
 
 
 def test_str_rule():
     rule = 'a <= 10.0 and b > 3.0'
-    assert(rule == str(Rule(rule)))
+    assert_equal(rule, str(Rule(rule)))
 
 
 def test_equals_rule():
     rule = "a == a"
-    assert(rule == str(Rule(rule)))
+    assert_equal(rule, str(Rule(rule)))
 
     rule2 = "a == a and a == a"
-    assert(rule == str(Rule(rule2)))
+    assert_equal(rule, str(Rule(rule2)))
 
     rule3 = "a < 3.0 and a == a"
-    assert(rule3 == str(Rule(rule3)))
+    assert_equal(rule3, str(Rule(rule3)))
 
 
 def test_replace_feature_name():
@@ -62,58 +62,4 @@ def test_replace_feature_name():
                     "__C__0": "$b",
                     "__C__1": "c(4)"
                     }
-    assert(replace_feature_name(rule, replace_dict=replace_dict)
-           == real_rule)
-
-
-def test_precision():
-    rule0 = ('a > 0', (0, 0, 0, 0))
-    rule1 = ('a > 0', (0, 1, 0, 1))
-
-    assert precision(rule0[1]) == 0
-    assert precision(rule1[1]) == 0.5
-
-
-def test_recall():
-    rule0 = ('a > 0', (0, 0, 0, 0))
-    rule1 = ('a > 0', (0, 0, 1, 1))
-
-    assert recall(rule0[1]) == 0
-    assert recall(rule1[1]) == 0.5
-
-
-def test_f1_score():
-    rule0 = ('a > 0', (0, 0, 0, 0))
-    rule1 = ('a > 0', (0, 1, 1, 1))
-
-    assert f1_score(rule0[1]) == 0
-    assert f1_score(rule1[1]) == 0.5
-
-
-def test_mcc_score():
-    rule0 = ('a > 0', (0, 1, 0, 1))
-    rule1 = ('a > 0', (0, 0, 1, 1))
-    rule2 = ('a > 0', (1, 1, 0, 0))
-    rule3 = ('a > 0', (1, 0, 1, 0))
-    rule4 = ('a > 0', (0, 0, 0, 0))
-    rule5 = ('a > 0', (1, 0, 0, 1))
-
-    assert mcc_score(rule0[1]) == 0
-    assert mcc_score(rule1[1]) == 0
-    assert mcc_score(rule2[1]) == 0
-    assert mcc_score(rule3[1]) == 0
-    assert mcc_score(rule4[1]) == 0
-    assert mcc_score(rule5[1]) == 1
-
-
-def test_get_confusion_matrix():
-    X = pd.DataFrame([[0, 1, 1], [1, 0, 1]], columns=['a', 'b', 'c'])
-    y = np.array([1, 0])
-
-    rule0 = 'a > 0'
-    rule1 = 'b > 0'
-    rule2 = 'c > 0'
-
-    assert get_confusion_matrix(rule0, X, y) == (0, 1, 1, 0)
-    assert get_confusion_matrix(rule1, X, y) == (1, 0, 0, 1)
-    assert get_confusion_matrix(rule2, X, y) == (0, 1, 0, 1)
+    assert_equal(replace_feature_name(rule, replace_dict=replace_dict), real_rule)

--- a/skrules/tests/test_skope_rules.py
+++ b/skrules/tests/test_skope_rules.py
@@ -1,19 +1,25 @@
 """
 Testing for SkopeRules algorithm (skrules.skope_rules).
 """
-import warnings
 
 import numpy as np
-from numpy.testing import assert_array_equal
-from numpy.testing import assert_raises
-from numpy.testing import assert_warns
-from numpy.testing import assert_no_warnings
 
 from sklearn.model_selection import ParameterGrid
 from sklearn.datasets import load_iris, load_boston, make_blobs
 from sklearn.metrics import accuracy_score
+
 from sklearn.utils import check_random_state
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_warns_message
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_in
+from sklearn.utils.testing import assert_not_in
+from sklearn.utils.testing import assert_not_equal
+from sklearn.utils.testing import assert_no_warnings
+from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import ignore_warnings
+
 
 from skrules import SkopeRules
 
@@ -41,11 +47,10 @@ def test_skope_rules():
     y_train = [0] * 6 + [1] * 2
     X_test = np.array([[2, 1], [1, 1]])
 
-    grid = ParameterGrid([{
+    grid = ParameterGrid({
         "feature_names": [None, ['a', 'b']],
-        "filtering_criteria": [{'precision': 0., 'recall': 0.}],
-        "duplication_criterion": ['f1', 'mcc'],
-        "custom_func": [None],
+        "precision_min": [0.],
+        "recall_min": [0.],
         "n_estimators": [1],
         "max_samples": [0.5, 4],
         "max_samples_features": [0.5, 2],
@@ -54,23 +59,7 @@ def test_skope_rules():
         "max_depth": [2],
         "max_features": ["auto", 1, 0.1],
         "min_samples_split": [2, 0.1],
-        "n_jobs": [-1, 2]},
-        # grid with custom_func parameter
-        {
-        "feature_names": [None, ['a', 'b']],
-        "filtering_criteria": [{'precision': 0., 'recall': 0., 'custom_func': 0}],
-        "duplication_criterion": ['f1', 'mcc', 'custom_func'],
-        "custom_func": [lambda mtx: mtx[0]],
-        "n_estimators": [1],
-        "max_samples": [0.5, 4],
-        "max_samples_features": [0.5, 2],
-        "bootstrap": [True, False],
-        "bootstrap_features": [True, False],
-        "max_depth": [2],
-        "max_features": ["auto", 1, 0.1],
-        "min_samples_split": [2, 0.1],
-        "n_jobs": [-1, 2]}]
-        )
+        "n_jobs": [-1, 2]})
 
     with ignore_warnings():
         for params in grid:
@@ -80,8 +69,8 @@ def test_skope_rules():
     # additional parameters:
     SkopeRules(n_estimators=50,
                max_samples=1.,
-               filtering_criteria={'precision': 0., 'recall': 0.}
-               ).fit(X_train, y_train).predict(X_test)
+               recall_min=0.,
+               precision_min=0.).fit(X_train, y_train).predict(X_test)
 
 
 def test_skope_rules_error():
@@ -98,44 +87,19 @@ def test_skope_rules_error():
     assert_raises(ValueError,
                   SkopeRules(max_samples=2.0).fit, X, y)
     # explicitly setting max_samples > n_samples should result in a warning.
-    assert_warns(UserWarning,
-                 SkopeRules(max_samples=1000).fit, X, y)
+    assert_warns_message(UserWarning,
+                         "max_samples will be set to n_samples for estimation",
+                         SkopeRules(max_samples=1000).fit, X, y)
     assert_no_warnings(SkopeRules(max_samples=np.int64(2)).fit, X, y)
     assert_raises(ValueError, SkopeRules(max_samples='foobar').fit, X, y)
     assert_raises(ValueError, SkopeRules(max_samples=1.5).fit, X, y)
-    with assert_raises(TypeError):
-        SkopeRules(max_depth_duplication=1.5).fit(X, y)
+    assert_raises(ValueError, SkopeRules(max_depth_duplication=1.5).fit, X, y)
     assert_raises(ValueError, SkopeRules().fit(X, y).predict, X[:, 1:])
     assert_raises(ValueError, SkopeRules().fit(X, y).decision_function,
                   X[:, 1:])
     assert_raises(ValueError, SkopeRules().fit(X, y).rules_vote, X[:, 1:])
     assert_raises(ValueError, SkopeRules().fit(X, y).score_top_rules,
                   X[:, 1:])
-    # check filtering_criteria errors
-    with assert_raises(TypeError):
-        SkopeRules(filtering_criteria=[]).fit(X, y)
-    with assert_raises(TypeError):
-        SkopeRules(filtering_criteria={}).fit(X, y)
-    with assert_raises(ValueError):
-        SkopeRules(filtering_criteria={'foobar': 0.}).fit(X, y)
-    with assert_raises(TypeError):
-        SkopeRules(filtering_criteria={'foo': 'bar'}).fit(X, y)
-    # check duplication_criterion errors
-    with assert_raises(ValueError):
-        SkopeRules(duplication_criterion=0).fit(X, y)
-    with assert_raises(ValueError):
-        SkopeRules(duplication_criterion='foobar').fit(X, y)
-    # check custom_func errors
-    with assert_raises(TypeError):
-        SkopeRules(duplication_criterion='custom_func', custom_func=None).fit(X, y)
-    with assert_raises(TypeError):
-        SkopeRules(filtering_criteria={'custom_func': 0.}, custom_func=None).fit(X, y)
-    with assert_raises(TypeError):
-        SkopeRules(duplication_criterion='custom_func',
-                   custom_func='foobar').fit(X, y)
-    with assert_raises(TypeError):
-        SkopeRules(duplication_criterion='custom_func',
-                   custom_func=lambda x: x).fit(X, y)
 
 
 def test_max_samples_attribute():
@@ -144,21 +108,21 @@ def test_max_samples_attribute():
     y = (y != 0)
 
     clf = SkopeRules(max_samples=1.).fit(X, y)
-    assert clf.max_samples_ == X.shape[0]
+    assert_equal(clf.max_samples_, X.shape[0])
 
     clf = SkopeRules(max_samples=500)
-    assert_warns(UserWarning,
-                 clf.fit, X, y)
-    assert clf.max_samples_ == X.shape[0]
+    assert_warns_message(UserWarning,
+                         "max_samples will be set to n_samples for estimation",
+                         clf.fit, X, y)
+    assert_equal(clf.max_samples_, X.shape[0])
 
     clf = SkopeRules(max_samples=0.4).fit(X, y)
-    assert clf.max_samples_ == 0.4*X.shape[0]
+    assert_equal(clf.max_samples_, 0.4*X.shape[0])
 
 
 def test_skope_rules_works():
     # toy sample (the last two samples are outliers)
-    X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [6, 3],
-         [4, -7]]
+    X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [6, 3], [4, -7]]
     y = [0] * 6 + [1] * 2
     X_test = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1],
               [10, 5], [5, -7]]
@@ -171,17 +135,17 @@ def test_skope_rules_works():
     pred = clf.predict(X_test)
     pred_score_top_rules = clf.predict_top_rules(X_test, 1)
     # assert detect outliers:
-    assert np.min(decision_func[-2:]) > np.max(decision_func[:-2])
-    assert np.min(rules_vote[-2:]) > np.max(rules_vote[:-2])
-    assert np.min(score_top_rules[-2:]) > np.max(score_top_rules[:-2])
+    assert_greater(np.min(decision_func[-2:]), np.max(decision_func[:-2]))
+    assert_greater(np.min(rules_vote[-2:]), np.max(rules_vote[:-2]))
+    assert_greater(np.min(score_top_rules[-2:]),
+                   np.max(score_top_rules[:-2]))
     assert_array_equal(pred, 6 * [0] + 2 * [1])
     assert_array_equal(pred_score_top_rules, 6 * [0] + 2 * [1])
 
 
 def test_deduplication_works():
     # toy sample (the last two samples are outliers)
-    X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [6, 3],
-         [4, -7]]
+    X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [6, 3], [4, -7]]
     y = [0] * 6 + [1] * 2
     X_test = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1],
               [10, 5], [5, -7]]
@@ -212,27 +176,26 @@ def test_performances():
     # with lists
     clf.fit(X.tolist(), y.tolist())
     y_pred = clf.predict(X)
-    assert y_pred.shape == (n_samples,)
+    assert_equal(y_pred.shape, (n_samples,))
     # training set performance
-    assert accuracy_score(y, y_pred) > 0.83
+    assert_greater(accuracy_score(y, y_pred), 0.83)
 
     # decision_function agrees with predict
     decision = -clf.decision_function(X)
-    assert decision.shape == (n_samples,)
+    assert_equal(decision.shape, (n_samples,))
     dec_pred = (decision.ravel() < 0).astype(np.int)
     assert_array_equal(dec_pred, y_pred)
 
 
 def test_similarity_tree():
     # Test that rules are well splitted
-    # tn, fp, fn, tp
-    rules = [("a <= 2 and b > 45 and c <= 3 and a > 4", (10, 0, 0, 10)),
-             ("a <= 2 and b > 45 and c <= 3 and a > 4", (10, 0, 0, 10)),
-             ("a > 2 and b > 45", (7, 3, 3, 7)),
-             ("a > 2 and b > 40", (6, 4, 4, 6)),
-             ("a <= 2 and b <= 45", (10, 0, 0, 10)),
-             ("a > 2 and c <= 3", (10, 0, 0, 10)),
-             ("b > 45", (10, 0, 0, 10)),
+    rules = [("a <= 2 and b > 45 and c <= 3 and a > 4", (1, 1, 0)),
+             ("a <= 2 and b > 45 and c <= 3 and a > 4", (1, 1, 0)),
+             ("a > 2 and b > 45", (0.5, 0.3, 0)),
+             ("a > 2 and b > 40", (0.5, 0.2, 0)),
+             ("a <= 2 and b <= 45", (1, 1, 0)),
+             ("a > 2 and c <= 3", (1, 1, 0)),
+             ("b > 45", (1, 1, 0)),
              ]
 
     sk = SkopeRules(max_depth_duplication=2)
@@ -246,10 +209,21 @@ def test_similarity_tree():
                 idx_bags_for_rule.append(idx_bag)
         idx_bags_rules.append(idx_bags_for_rule)
 
-    assert idx_bags_rules[0] == idx_bags_rules[1]
-    assert idx_bags_rules[0] != idx_bags_rules[2]
+    assert_equal(idx_bags_rules[0], idx_bags_rules[1])
+    assert_not_equal(idx_bags_rules[0], idx_bags_rules[2])
     # Assert the best rules are kept
-    final_rules = sk._deduplicate(rules)
-    assert rules[0] in final_rules
-    assert rules[2] in final_rules
-    assert rules[3] not in final_rules
+    final_rules = sk.deduplicate(rules)
+    assert_in(rules[0], final_rules)
+    assert_in(rules[2], final_rules)
+    assert_not_in(rules[3], final_rules)
+
+
+def test_f1_score():
+    clf = SkopeRules()
+    rule0 = ('a > 0', (0, 0, 0))
+    rule1 = ('a > 0', (0.5, 0.5, 0))
+    rule2 = ('a > 0', (0.5, 0, 0))
+
+    assert_equal(clf.f1_score(rule0), 0)
+    assert_equal(clf.f1_score(rule1), 0.5)
+    assert_equal(clf.f1_score(rule2), 0)

--- a/skrules/tests/test_skope_rules.py
+++ b/skrules/tests/test_skope_rules.py
@@ -1,25 +1,19 @@
 """
 Testing for SkopeRules algorithm (skrules.skope_rules).
 """
+import warnings
 
 import numpy as np
+from numpy.testing import assert_array_equal
+from numpy.testing import assert_raises
+from numpy.testing import assert_warns
+from numpy.testing import assert_no_warnings
 
 from sklearn.model_selection import ParameterGrid
 from sklearn.datasets import load_iris, load_boston, make_blobs
 from sklearn.metrics import accuracy_score
-
 from sklearn.utils import check_random_state
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_warns_message
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_in
-from sklearn.utils.testing import assert_not_in
-from sklearn.utils.testing import assert_not_equal
-from sklearn.utils.testing import assert_no_warnings
-from sklearn.utils.testing import assert_greater
 from sklearn.utils.testing import ignore_warnings
-
 
 from skrules import SkopeRules
 
@@ -47,10 +41,11 @@ def test_skope_rules():
     y_train = [0] * 6 + [1] * 2
     X_test = np.array([[2, 1], [1, 1]])
 
-    grid = ParameterGrid({
+    grid = ParameterGrid([{
         "feature_names": [None, ['a', 'b']],
-        "precision_min": [0.],
-        "recall_min": [0.],
+        "filtering_criteria": [{'precision': 0., 'recall': 0.}],
+        "duplication_criterion": ['f1', 'mcc'],
+        "custom_func": [None],
         "n_estimators": [1],
         "max_samples": [0.5, 4],
         "max_samples_features": [0.5, 2],
@@ -59,7 +54,23 @@ def test_skope_rules():
         "max_depth": [2],
         "max_features": ["auto", 1, 0.1],
         "min_samples_split": [2, 0.1],
-        "n_jobs": [-1, 2]})
+        "n_jobs": [-1, 2]},
+        # grid with custom_func parameter
+        {
+        "feature_names": [None, ['a', 'b']],
+        "filtering_criteria": [{'precision': 0., 'recall': 0., 'custom_func': 0}],
+        "duplication_criterion": ['f1', 'mcc', 'custom_func'],
+        "custom_func": [lambda mtx: mtx[0]],
+        "n_estimators": [1],
+        "max_samples": [0.5, 4],
+        "max_samples_features": [0.5, 2],
+        "bootstrap": [True, False],
+        "bootstrap_features": [True, False],
+        "max_depth": [2],
+        "max_features": ["auto", 1, 0.1],
+        "min_samples_split": [2, 0.1],
+        "n_jobs": [-1, 2]}]
+        )
 
     with ignore_warnings():
         for params in grid:
@@ -69,8 +80,8 @@ def test_skope_rules():
     # additional parameters:
     SkopeRules(n_estimators=50,
                max_samples=1.,
-               recall_min=0.,
-               precision_min=0.).fit(X_train, y_train).predict(X_test)
+               filtering_criteria={'precision': 0., 'recall': 0.}
+               ).fit(X_train, y_train).predict(X_test)
 
 
 def test_skope_rules_error():
@@ -87,19 +98,44 @@ def test_skope_rules_error():
     assert_raises(ValueError,
                   SkopeRules(max_samples=2.0).fit, X, y)
     # explicitly setting max_samples > n_samples should result in a warning.
-    assert_warns_message(UserWarning,
-                         "max_samples will be set to n_samples for estimation",
-                         SkopeRules(max_samples=1000).fit, X, y)
+    assert_warns(UserWarning,
+                 SkopeRules(max_samples=1000).fit, X, y)
     assert_no_warnings(SkopeRules(max_samples=np.int64(2)).fit, X, y)
     assert_raises(ValueError, SkopeRules(max_samples='foobar').fit, X, y)
     assert_raises(ValueError, SkopeRules(max_samples=1.5).fit, X, y)
-    assert_raises(ValueError, SkopeRules(max_depth_duplication=1.5).fit, X, y)
+    with assert_raises(TypeError):
+        SkopeRules(max_depth_duplication=1.5).fit(X, y)
     assert_raises(ValueError, SkopeRules().fit(X, y).predict, X[:, 1:])
     assert_raises(ValueError, SkopeRules().fit(X, y).decision_function,
                   X[:, 1:])
     assert_raises(ValueError, SkopeRules().fit(X, y).rules_vote, X[:, 1:])
     assert_raises(ValueError, SkopeRules().fit(X, y).score_top_rules,
                   X[:, 1:])
+    # check filtering_criteria errors
+    with assert_raises(TypeError):
+        SkopeRules(filtering_criteria=[]).fit(X, y)
+    with assert_raises(TypeError):
+        SkopeRules(filtering_criteria={}).fit(X, y)
+    with assert_raises(ValueError):
+        SkopeRules(filtering_criteria={'foobar': 0.}).fit(X, y)
+    with assert_raises(TypeError):
+        SkopeRules(filtering_criteria={'foo': 'bar'}).fit(X, y)
+    # check duplication_criterion errors
+    with assert_raises(ValueError):
+        SkopeRules(duplication_criterion=0).fit(X, y)
+    with assert_raises(ValueError):
+        SkopeRules(duplication_criterion='foobar').fit(X, y)
+    # check custom_func errors
+    with assert_raises(TypeError):
+        SkopeRules(duplication_criterion='custom_func', custom_func=None).fit(X, y)
+    with assert_raises(TypeError):
+        SkopeRules(filtering_criteria={'custom_func': 0.}, custom_func=None).fit(X, y)
+    with assert_raises(TypeError):
+        SkopeRules(duplication_criterion='custom_func',
+                   custom_func='foobar').fit(X, y)
+    with assert_raises(TypeError):
+        SkopeRules(duplication_criterion='custom_func',
+                   custom_func=lambda x: x).fit(X, y)
 
 
 def test_max_samples_attribute():
@@ -108,21 +144,21 @@ def test_max_samples_attribute():
     y = (y != 0)
 
     clf = SkopeRules(max_samples=1.).fit(X, y)
-    assert_equal(clf.max_samples_, X.shape[0])
+    assert clf.max_samples_ == X.shape[0]
 
     clf = SkopeRules(max_samples=500)
-    assert_warns_message(UserWarning,
-                         "max_samples will be set to n_samples for estimation",
-                         clf.fit, X, y)
-    assert_equal(clf.max_samples_, X.shape[0])
+    assert_warns(UserWarning,
+                 clf.fit, X, y)
+    assert clf.max_samples_ == X.shape[0]
 
     clf = SkopeRules(max_samples=0.4).fit(X, y)
-    assert_equal(clf.max_samples_, 0.4*X.shape[0])
+    assert clf.max_samples_ == 0.4*X.shape[0]
 
 
 def test_skope_rules_works():
     # toy sample (the last two samples are outliers)
-    X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [6, 3], [4, -7]]
+    X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [6, 3],
+         [4, -7]]
     y = [0] * 6 + [1] * 2
     X_test = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1],
               [10, 5], [5, -7]]
@@ -135,17 +171,17 @@ def test_skope_rules_works():
     pred = clf.predict(X_test)
     pred_score_top_rules = clf.predict_top_rules(X_test, 1)
     # assert detect outliers:
-    assert_greater(np.min(decision_func[-2:]), np.max(decision_func[:-2]))
-    assert_greater(np.min(rules_vote[-2:]), np.max(rules_vote[:-2]))
-    assert_greater(np.min(score_top_rules[-2:]),
-                   np.max(score_top_rules[:-2]))
+    assert np.min(decision_func[-2:]) > np.max(decision_func[:-2])
+    assert np.min(rules_vote[-2:]) > np.max(rules_vote[:-2])
+    assert np.min(score_top_rules[-2:]) > np.max(score_top_rules[:-2])
     assert_array_equal(pred, 6 * [0] + 2 * [1])
     assert_array_equal(pred_score_top_rules, 6 * [0] + 2 * [1])
 
 
 def test_deduplication_works():
     # toy sample (the last two samples are outliers)
-    X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [6, 3], [4, -7]]
+    X = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1], [6, 3],
+         [4, -7]]
     y = [0] * 6 + [1] * 2
     X_test = [[-2, -1], [-1, -1], [-1, -2], [1, 1], [1, 2], [2, 1],
               [10, 5], [5, -7]]
@@ -176,26 +212,27 @@ def test_performances():
     # with lists
     clf.fit(X.tolist(), y.tolist())
     y_pred = clf.predict(X)
-    assert_equal(y_pred.shape, (n_samples,))
+    assert y_pred.shape == (n_samples,)
     # training set performance
-    assert_greater(accuracy_score(y, y_pred), 0.83)
+    assert accuracy_score(y, y_pred) > 0.83
 
     # decision_function agrees with predict
     decision = -clf.decision_function(X)
-    assert_equal(decision.shape, (n_samples,))
+    assert decision.shape == (n_samples,)
     dec_pred = (decision.ravel() < 0).astype(np.int)
     assert_array_equal(dec_pred, y_pred)
 
 
 def test_similarity_tree():
     # Test that rules are well splitted
-    rules = [("a <= 2 and b > 45 and c <= 3 and a > 4", (1, 1, 0)),
-             ("a <= 2 and b > 45 and c <= 3 and a > 4", (1, 1, 0)),
-             ("a > 2 and b > 45", (0.5, 0.3, 0)),
-             ("a > 2 and b > 40", (0.5, 0.2, 0)),
-             ("a <= 2 and b <= 45", (1, 1, 0)),
-             ("a > 2 and c <= 3", (1, 1, 0)),
-             ("b > 45", (1, 1, 0)),
+    # tn, fp, fn, tp
+    rules = [("a <= 2 and b > 45 and c <= 3 and a > 4", (10, 0, 0, 10)),
+             ("a <= 2 and b > 45 and c <= 3 and a > 4", (10, 0, 0, 10)),
+             ("a > 2 and b > 45", (7, 3, 3, 7)),
+             ("a > 2 and b > 40", (6, 4, 4, 6)),
+             ("a <= 2 and b <= 45", (10, 0, 0, 10)),
+             ("a > 2 and c <= 3", (10, 0, 0, 10)),
+             ("b > 45", (10, 0, 0, 10)),
              ]
 
     sk = SkopeRules(max_depth_duplication=2)
@@ -209,21 +246,10 @@ def test_similarity_tree():
                 idx_bags_for_rule.append(idx_bag)
         idx_bags_rules.append(idx_bags_for_rule)
 
-    assert_equal(idx_bags_rules[0], idx_bags_rules[1])
-    assert_not_equal(idx_bags_rules[0], idx_bags_rules[2])
+    assert idx_bags_rules[0] == idx_bags_rules[1]
+    assert idx_bags_rules[0] != idx_bags_rules[2]
     # Assert the best rules are kept
-    final_rules = sk.deduplicate(rules)
-    assert_in(rules[0], final_rules)
-    assert_in(rules[2], final_rules)
-    assert_not_in(rules[3], final_rules)
-
-
-def test_f1_score():
-    clf = SkopeRules()
-    rule0 = ('a > 0', (0, 0, 0))
-    rule1 = ('a > 0', (0.5, 0.5, 0))
-    rule2 = ('a > 0', (0.5, 0, 0))
-
-    assert_equal(clf.f1_score(rule0), 0)
-    assert_equal(clf.f1_score(rule1), 0.5)
-    assert_equal(clf.f1_score(rule2), 0)
+    final_rules = sk._deduplicate(rules)
+    assert rules[0] in final_rules
+    assert rules[2] in final_rules
+    assert rules[3] not in final_rules

--- a/skrules/utils/__init__.py
+++ b/skrules/utils/__init__.py
@@ -1,0 +1,6 @@
+from .checks import check_filtering_criteria
+from .checks import check_deduplication_criterion
+from .checks import check_custom_func
+from .checks import check_consistency
+from .checks import check_max_depth_duplication
+from .checks import check_max_samples

--- a/skrules/utils/__init__.py
+++ b/skrules/utils/__init__.py
@@ -3,4 +3,8 @@ from .checks import check_deduplication_criterion
 from .checks import check_custom_func
 from .checks import check_consistency
 from .checks import check_max_depth_duplication
-from .checks import check_max_samples
+from .util import get_confusion_matrix
+from .util import precision
+from .util import recall
+from .util import mcc_score
+from .util import f1_score

--- a/skrules/utils/__init__.py
+++ b/skrules/utils/__init__.py
@@ -3,6 +3,7 @@ from .checks import check_deduplication_criterion
 from .checks import check_custom_func
 from .checks import check_consistency
 from .checks import check_max_depth_duplication
+from .checks import check_max_samples
 from .util import get_confusion_matrix
 from .util import precision
 from .util import recall

--- a/skrules/utils/checks.py
+++ b/skrules/utils/checks.py
@@ -43,11 +43,11 @@ def check_custom_func(custom_func):
                           (types.FunctionType, types.BuiltinFunctionType)
                           ):
             raise TypeError("custom_func should be a function")
-        elif custom_func.__code__.co_argcount != 4:
-            raise ValueError("custom_func must have 4 arguments: tp, fp, fn, tp")
+        elif custom_func.__code__.co_argcount != 1:
+            raise ValueError("custom_func must have 1 argument: (tp, fp, fn, tp)")
 
         try:
-            if not isinstance(custom_func(0, 0, 0, 0), (float, int)):
+            if not isinstance(custom_func((0, 0, 0, 0)), (float, int)):
                 raise TypeError("custom_func should return a float or an int")
         except TypeError:
             raise TypeError("custom_func should take int as parameters")

--- a/skrules/utils/checks.py
+++ b/skrules/utils/checks.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+import types
+import six
+import numbers
+import numpy as np
+from warnings import warn
+
+INTEGER_TYPES = (numbers.Integral, np.integer)
+
+
+def check_filtering_criteria(criteria,
+                             valid_criteria=['precision',
+                                             'recall',
+                                             'f1',
+                                             'mcc',
+                                             'custom_func']
+                             ):
+    if not isinstance(criteria, dict):
+        raise TypeError("filtering_criteria should be a dict")
+    elif len(criteria) < 1:
+        raise TypeError("filtering_criteria should contain at least one key")
+    elif not all(isinstance(key, str) for key in criteria) or \
+            not all(isinstance(value, (float, int))
+                    for value in criteria.values()
+                    ):
+        raise TypeError("filtering_criteria should be {str: int or float}")
+    elif not all((x in valid_criteria) for x in criteria):
+        raise ValueError("The keys of filtering_criteria should be in: "
+                         + str(valid_criteria))
+
+
+def check_deduplication_criterion(criterion,
+                                  valid_criteria=['f1', 'mcc', 'custom_func']
+                                  ):
+    if not isinstance(criterion, str) or criterion not in valid_criteria:
+        raise ValueError("deduplication_criterion should be a string in: "
+                         + str(valid_criteria))
+
+
+def check_custom_func(custom_func):
+    if custom_func is not None:
+        if not isinstance(custom_func,
+                          (types.FunctionType, types.BuiltinFunctionType)
+                          ):
+            raise TypeError("custom_func should be a function")
+        elif custom_func.__code__.co_argcount != 4:
+            raise ValueError("custom_func must have 4 arguments: tp, fp, fn, tp")
+
+        try:
+            if not isinstance(custom_func(0, 0, 0, 0), (float, int)):
+                raise TypeError("custom_func should return a float or an int")
+        except TypeError:
+            raise TypeError("custom_func should take int as parameters")
+
+
+def check_consistency(custom_func, deduplication_criterion, filtering_criteria):
+    if 'custom_func' in filtering_criteria or 'custom_func' in deduplication_criterion:
+        if custom_func is None:
+            raise TypeError("custom_func is not define !")
+    if custom_func is not None:
+        if 'custom_func' not in filtering_criteria and \
+                'custom_func' not in deduplication_criterion:
+            warn("custom_func is define but not used !")
+
+
+def check_max_depth_duplication(max_depth_duplication):
+    if not isinstance(max_depth_duplication, int) \
+            and max_depth_duplication is not None:
+        raise TypeError("max_depth_duplication should be an integer")
+
+
+def check_max_samples(max_samples, n_samples):
+    if isinstance(max_samples, six.string_types):
+        raise ValueError('max_samples (%s) is not supported.'
+                         'Valid choices are: "auto", int or'
+                         'float' % max_samples)
+
+    elif isinstance(max_samples, INTEGER_TYPES):
+        if max_samples > n_samples:
+            warn("max_samples (%s) is greater than the "
+                 "total number of samples (%s). max_samples "
+                 "will be set to n_samples for estimation."
+                 % (max_samples, n_samples))
+            max_samples_ = n_samples
+        else:
+            max_samples_ = max_samples
+
+    else:  # float
+        if not (0. < max_samples <= 1.):
+            raise ValueError("max_samples must be in (0, 1], got %r"
+                             % max_samples)
+        max_samples_ = int(max_samples * n_samples)
+
+    return max_samples_

--- a/skrules/utils/util.py
+++ b/skrules/utils/util.py
@@ -1,0 +1,138 @@
+# -*- coding: utf8 -*-
+
+import numpy as np
+from sklearn.utils import indices_to_mask
+
+
+def get_confusion_matrix(rule, test_x, test_y):
+    """Return the confusion matrix of a rule given the data (X,y)
+    in the form (tn, fp, fn, tp)
+
+    Parameters
+    ----------
+        rule: Rule
+            The rule which is being evaluated on the data (X,y)
+        test_x: array-like, shape (n_samples, n_features)
+            Training vector, where n_samples is the number of samples
+            and n_features is the number of features
+        test_y: array-like, shape (n_samples,)
+            Target vector relative to X. Has to follow the convention
+            0 for normal data, 1 for anomalies
+
+    Returns
+    -------
+        tuple
+            Confusion matrix
+    """
+    # not using confusion_matrix function from sklearn.metrics
+    # for computation time perfs reasons
+    n_samples, _ = test_x.shape
+
+    detected_indices = list(test_x.query(rule).index)
+    if len(detected_indices) < 1:
+        return 0, 0, 0, 0
+    y_detected = test_y[detected_indices]
+
+    undetected_indices = ~indices_to_mask(detected_indices, n_samples)
+    y_undetected = test_y[undetected_indices]
+
+    tp = len(y_detected[y_detected == 1])
+    fp = len(y_detected[y_detected == 0])
+    tn = len(y_undetected[y_undetected == 0])
+    fn = len(y_undetected[y_undetected == 1])
+
+    return tn, fp, fn, tp
+
+
+def precision(confusion_matrix):
+    """Compute the precision of a given rule according
+    to its confusion matrix
+
+    Parameters
+    ----------
+    confusion_matrix : tuple
+        Confusion matrix (tn, fp, fn, tp)
+
+    Returns
+    -------
+        float
+            Precision
+    """
+    tn, fp, fn, tp = confusion_matrix
+
+    return tp / (tp + fp) if (tp + fp) > 0 else 0
+
+
+def recall(confusion_matrix):
+    """Compute the recall of a given rule according
+    to its confusion matrix
+
+    Parameters
+    ----------
+    confusion_matrix : tuple
+        Confusion matrix (tn, fp, fn, tp)
+
+    Returns
+    -------
+        float
+            Recall
+    """
+    tn, fp, fn, tp = confusion_matrix
+
+    return tp / (tp + fn) if (tp + fn) > 0 else 0
+
+
+def mcc_score(confusion_matrix):
+    """Compute the Matthews Correlation Coefficient of
+    a given rule according to its confusion matrix
+
+    Parameters
+    ----------
+        confusion_matrix : tuple
+            Confusion matrix (tn, fp, fn, tp)
+
+
+    Returns
+    -------
+        float
+            MCC score : value is between -1 and +1
+                +1: perfect prediction
+                0: no better than random prediction
+                -1: total disagreement between prediction and observation
+    """
+    # retrieving confusion matrix
+    tn, fp, fn, tp = confusion_matrix
+
+    numerator = (tp*tn - fp*fn)
+    if all(x > 0 for x in (tp + fp, tp + fn, tn + fp, tn + fn)):
+        # using log and exp to prevent overflow
+        denominator = (np.log(tp + fp)
+                       + np.log(tp + fn)
+                       + np.log(tn + fp)
+                       + np.log(tn + fn))
+        denominator = np.exp(1 / 2*denominator)
+
+        return numerator / denominator
+
+    else:
+        return 0
+
+
+def f1_score(confusion_matrix):
+    """Compute the F1-score of a given rule
+    (harmonic mean of the precision and recall)
+
+    Parameters
+    ----------
+        confusion_matrix : tuple
+            Confusion matrix (tn, fp, fn, tp)
+
+    Returns
+    -------
+        Float
+            F1-score : value is between 0 and 1
+    """
+    pre = precision(confusion_matrix)
+    rec = recall(confusion_matrix)
+
+    return 2*pre*rec / (pre + rec) if (pre + rec) > 0 else 0


### PR DESCRIPTION
Hello,

I've added two features (filtering and deduplication criteria) for skope rules.  

This work is an improvement of banch; arplas/skope-rules:

We have 3 new parameters for  SkopeRule class :
-  "filtering_criteria" in place of recall_min et precision_min
```
filtering_criteria: dict, optional
                    default={'precision': 0.5, 'recall': 0.01}
    The criteria to be used for filtering the rules.
    In the form {criterion: min_value}.
    The keys can be among ('precision', 'recall', 'f1', 'mcc', 'custom_func').
```

- "deduplication_criterion" in place of the default F1 score deduplication criterion which was used in deduplicate function

```
deduplication_criterion: str, optional (default='f1')
    The criterion to be used for deduplicating the rules.
    Either 'f1', 'mcc' or 'custom_func'.
```

- "custom_func"  parameter 

```
custom_func: FunctionType, optional (default=None)
    A personalised function that can be used as either/both a filtering
    or/and deduplication criterion.
    Has to take 1 parameter (tuple of size 4) which is supposed to be the confusion matrix
    elements (tn, fp, fn, tp) (in that order).

```