### PR TITLE
Fix broken import in skope_rules.py in 3.10

### DIFF
--- a/skrules/skope_rules.py
+++ b/skrules/skope_rules.py
@@ -1,5 +1,6 @@
 import numpy as np
-from collections import Counter, Iterable
+from collections import Counter
+from collections.abc import Iterable
 import pandas
 import numbers
 from warnings import warn


### PR DESCRIPTION
Due to the removal of `Iterable` from `collections`, `skrules/skope_rules.py` cannot be imported under Python 3.10.
This PR fixes this issue